### PR TITLE
Allow using pagesdisplay in user and file blueprints

### DIFF
--- a/src/PagesDisplaySection.php
+++ b/src/PagesDisplaySection.php
@@ -29,6 +29,19 @@ $extension = [
         'type' => fn() => 'pages',
     ],
     'computed' => [
+        'parent' => function () {
+            $parent = $this->parentModel();
+            
+            if (
+                $parent instanceof \Kirby\Cms\Site === false &&
+                $parent instanceof \Kirby\Cms\Page === false &&
+                $this->query === 'page.children'
+            ) {
+                throw new InvalidArgumentException("You must provide a query when using pagesdisplay in a user or file blueprint.");
+            }
+            
+            return $parent;
+        },
         'pages' => function () {
             $kirby = kirby();
             $q = new Query($this->query, [


### PR DESCRIPTION
The native `pages` section can only be used on page and site blueprints, not on user or file blueprints. As far as I can tell, there is no reason to prevent using `pagesdisplay` everywhere, i.e on a user view to show their latest contributions. But in this case a query value needs to be present.  https://github.com/getkirby/kirby/blob/3.8.3/config/sections/pages.php#L54